### PR TITLE
remove fail('Unsupported') for Debian

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,7 +32,7 @@ class alternatives::params {
             default: { fail("Unsupported Ubuntu version! - ${::operatingsystemrelease}")  }
           }
         }
-        'Debian': { fail('Unsupported')  }
+        'Debian': { }
         default: { fail('Unsupported Debian flavour!')  }
       }
     }


### PR DESCRIPTION
I'm using it. Works neatly.